### PR TITLE
Document Claude Code skills in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ commands are available to everyone who clones the repo.
 
 ### Skills
 
+- **`/plan [task description]`** — Plans the implementation approach before any
+  code is written. It enters Plan mode (read-only), explores the codebase, and
+  presents an approach for your approval. Use it before starting non-trivial work.
 - **`/review [PR number, GitHub URL, or branch — omit for current branch]`** —
   Runs a multi-agent code review. It routes the diff to focused review agents,
   synthesizes their findings by severity (🔴 / 🟠 / 🟡), and can post the result
   as a PR comment.
-- **`/plan [task description]`** — Plans the implementation approach before any
-  code is written. It enters Plan mode (read-only), explores the codebase, and
-  presents an approach for your approval. Use it before starting non-trivial work.
 
 ### Review agents
 

--- a/README.md
+++ b/README.md
@@ -51,3 +51,31 @@ Rails server process and a local Tailwind process. To start them, run:
 ```
 bin/dev
 ```
+
+## Claude Code
+
+This repo includes custom [Claude Code](https://claude.com/claude-code) tooling
+under `.claude/`. If you use Claude Code in this project, the following slash
+commands are available to everyone who clones the repo.
+
+### Skills
+
+- **`/review [PR number, GitHub URL, or branch — omit for current branch]`** —
+  Runs a multi-agent code review. It routes the diff to focused review agents,
+  synthesizes their findings by severity (🔴 / 🟠 / 🟡), and can post the result
+  as a PR comment.
+- **`/plan [task description]`** — Plans the implementation approach before any
+  code is written. It enters Plan mode (read-only), explores the codebase, and
+  presents an approach for your approval. Use it before starting non-trivial work.
+
+### Review agents
+
+`/review` is backed by a handful of focused agents in `.claude/agents/`, each
+applying one lens to the change:
+
+- **`review-rails`** — correctness, bugs, and idiomatic Rails conventions.
+- **`review-security`** — authentication, authorization, mass assignment, and injection.
+- **`review-simplicity`** — over-engineering, duplication, and dead code (YAGNI).
+- **`review-testing`** — RSpec/FactoryBot coverage and test quality.
+
+See [`CLAUDE.md`](CLAUDE.md) for the code conventions these tools enforce.


### PR DESCRIPTION
## Summary
Adds a **Claude Code** section to the README documenting the custom tooling under `.claude/`, so contributors discover it after cloning. Docs-only — no application code changes.

## What's added
- **Skills** — `/review` (multi-agent code review) and `/plan` (Plan-mode implementation planning), each with its slash-command usage and argument hint.
- **Review agents** — the four focused agents backing `/review` (`review-rails`, `review-security`, `review-simplicity`, `review-testing`), each with its one-line lens.
- A pointer to `CLAUDE.md` for the conventions these tools enforce.

Descriptions are sourced from the skills'/agents' own frontmatter to stay consistent.

## Verification
- Change is purely additive (28 insertions, 0 removals) — no existing README content altered.
- Headings nest correctly under a new `## Claude Code` section; slash commands are code-formatted.
- No Ruby changed; RSpec and standardrb remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)