### PR TITLE
Seed bulk task volume for the SRE performance deep-dive

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,3 +43,32 @@ tasks = [
 tasks.each do |attributes|
   Task.where(title: attributes[:title]).first_or_create!(attributes.except(:title))
 end
+
+# Bulk volume so the task index is *visibly* slow once an N+1 lands on it (e.g.
+# rendering an assignee per row without eager loading) — the performance
+# deep-dive needs a real symptom to diagnose. Skipped in test so the suite stays
+# fast and task counts stay predictable; override the target with SEED_TASK_COUNT.
+target_count = ENV.fetch("SEED_TASK_COUNT", Rails.env.test? ? 0 : 2_000).to_i
+
+if Task.count < target_count
+  now = Time.current
+  verbs = %w[Book Confirm Email Review Draft Plan Order Sync Archive Update Reconcile Schedule Cancel Rebook Invoice]
+  destinations = %w[Lisbon Kyoto Marrakech Patagonia Reykjavik Hanoi Cusco Porto Split Tbilisi Oaxaca Lagos]
+  nouns = ["itinerary", "hotel block", "flight change", "transfer", "deposit", "welcome packet", "visa", "insurance", "budget", "supplier contract"]
+
+  rows = Array.new(target_count - Task.count) do
+    title = "#{verbs.sample} #{destinations.sample} #{nouns.sample}"
+    # Mix in the occasional lowercase title so case-sensitivity bites at volume.
+    title = title.downcase if rand < 0.1
+
+    {
+      title: title,
+      complete: rand < 0.4,
+      description: (Faker::Lorem.sentence(word_count: rand(4..10)) if rand < 0.7),
+      created_at: now,
+      updated_at: now
+    }
+  end
+
+  rows.each_slice(1_000) { |slice| Task.insert_all(slice) }
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,24 +47,12 @@ end
 # By default only the curated tasks above are seeded. Set SEED_TASK_COUNT to
 # top the table up to a larger backlog when you need volume.
 target_count = ENV.fetch("SEED_TASK_COUNT", 16).to_i
+missing = target_count - Task.count
 
-if Task.count < target_count
+if missing.positive?
   now = Time.current
-  verbs = %w[Book Confirm Email Review Draft Plan Order Sync Archive Update Reconcile Schedule Cancel Rebook Invoice]
-  destinations = %w[Lisbon Kyoto Marrakech Patagonia Reykjavik Hanoi Cusco Porto Split Tbilisi Oaxaca Lagos]
-  nouns = ["itinerary", "hotel block", "flight change", "transfer", "deposit", "welcome packet", "visa", "insurance", "budget", "supplier contract"]
-
-  rows = Array.new(target_count - Task.count) do
-    title = "#{verbs.sample} #{destinations.sample} #{nouns.sample}"
-    title = title.downcase if rand < 0.1
-
-    {
-      title: title,
-      complete: rand < 0.4,
-      description: (Faker::Lorem.sentence(word_count: rand(4..10)) if rand < 0.7),
-      created_at: now,
-      updated_at: now
-    }
+  rows = Array.new(missing) do |index|
+    {title: "Backlog task #{index + 1}", complete: index.even?, created_at: now, updated_at: now}
   end
 
   rows.each_slice(1_000) { |slice| Task.insert_all(slice) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,11 +44,9 @@ tasks.each do |attributes|
   Task.where(title: attributes[:title]).first_or_create!(attributes.except(:title))
 end
 
-# Bulk volume so the task index is *visibly* slow once an N+1 lands on it (e.g.
-# rendering an assignee per row without eager loading) — the performance
-# deep-dive needs a real symptom to diagnose. Skipped in test so the suite stays
-# fast and task counts stay predictable; override the target with SEED_TASK_COUNT.
-target_count = ENV.fetch("SEED_TASK_COUNT", Rails.env.test? ? 0 : 2_000).to_i
+# By default only the curated tasks above are seeded. Set SEED_TASK_COUNT to
+# top the table up to a larger backlog when you need volume.
+target_count = ENV.fetch("SEED_TASK_COUNT", 16).to_i
 
 if Task.count < target_count
   now = Time.current
@@ -58,7 +56,6 @@ if Task.count < target_count
 
   rows = Array.new(target_count - Task.count) do
     title = "#{verbs.sample} #{destinations.sample} #{nouns.sample}"
-    # Mix in the occasional lowercase title so case-sensitivity bites at volume.
     title = title.downcase if rand < 0.1
 
     {


### PR DESCRIPTION
What & why
----------
The SRE-track interview drops a live performance deep-dive ("the task list takes ~4s to load"), which needs the task index to carry real volume before an N+1 will visibly show. The curated 16-task seed is too small.

This adds an **opt-in** volume knob to `db/seeds.rb`. `SEED_TASK_COUNT` defaults to 16, so a fresh clone is unchanged — the curated tasks (which carry the filter/sort/case traps) are all you get. Set `SEED_TASK_COUNT=<n>` before an interview to top the table up to `n` deterministic filler tasks (`Backlog task N`, alternating complete/incomplete), inserted with `insert_all` in batches of 1,000. The guard tops up to the target and no-ops thereafter, so re-running never duplicate-grows. Defaulting to the curated set (rather than to bulk) keeps production and other envs from getting junk rows.

Only volume is seeded here. The assignee column the N+1 hangs off is the candidate’s to add during the exercise, so seeds leave it alone by design.

Verify
------
- `bin/rails db:seed` → `Task.count` is 16 (unchanged default).
- `SEED_TASK_COUNT=2000 bin/rails db:seed` → 2,000 tasks; re-running stays at 2,000.
- `RAILS_ENV=test bin/rails db:seed:replant` → 16 tasks; CI seed-replant step stays green.